### PR TITLE
Lazy load clojure.data.json when zero-arg calls made to SQS consumer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,19 @@ jobs:
         type: boolean
         default: True
     docker:
-      - image: circleci/clojure:openjdk-11-lein
+      - image: cimg/clojure:1.10.1
         auth:
           # from org-global context
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASS
+      - image: localstack/localstack:0.12.6
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASS
+        environment:
+          DEFAULT_REGION: "eu-west-1"
+          SERVICES: "s3,sqs,sns"
+
     steps:
       - checkout
 
@@ -28,12 +36,42 @@ jobs:
               - ~/.m2
           key: v1-deps-lein-{{ checksum "project.clj" }}
 
-      - run: lein uberjar
+      - run:
+          name: Waiting for Localstack to be ready
+          command: |
+            for i in `seq 1 30`;
+            do
+              nc -z 127.0.0.1 4566 && echo Success && exit 0
+              echo -n .
+              sleep 1
+            done
+            echo Failed waiting for Localstack && exit 1
+
+      - run:
+          name: Run tests
+          command: |
+            lein test unit \
+              --no-capture-output \
+              --plugin cloverage \
+              --plugin kaocha.plugin/junit-xml \
+              --junit-xml-file test-results/clojure/results.xml
+
+      - store_test_results:
+          path: test-results
+
+      - store_artifacts:
+          path: target/coverage
+
+      - run:
+          name: Build jar
+          command: lein uberjar
 
       - when:
           condition: << parameters.publish >>
           steps:
-            - run: lein deploy
+            - run:
+                name: Deploy to clojars
+                command: lein deploy
 
 workflows:
   version: 2
@@ -55,6 +93,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
                 - main
+                - master
           context: org-global

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .hgignore
 .hg/
 .calva
+.lsp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,102 @@
 # Changelog
 
-## 0.1.9-SNAPSHOT
-
-### Added
-
--   parallel processing namespace (using Claypoole)
+## 0.3.0
 
 ### Breaking
 
--   `core/create-consumer` no longer accepts a variable number of arguments, instead requires an object of options. Other namespaces remain unchanged
+-   Remove:
+
+    -   `sequential/with-decoder`
+    -   `parallel/with-decoder`
+    -   `utils/decode-sns-encoded-json`
+
+    Added new decoding utility higher-order functions. These take a `json-fn` which decodes a JSON string as a first argument, or fallback to clojure.data.json if only one argumetn is specified and the clojure.data.json is found on the classpath:
+
+    -   `utils/sqs-encoded-json-decoder`
+    -   `utils/sns-encoded-json-decoder`
+    -   `utils/auto-json-decoder`
+
+    The SNS functions additionally take the message attributes from the SNS payload and add them to `message-attributes` (see below).
+
+-   Remove bundling of `clojure.data.json`
+-   Changed signature of process-fn. It now receives a map:
+
+    ```clojure
+    {;; the original message, with unparsed body.
+    :message message
+    ;; attributes on the message, note these are different to message-attributes, e.g. ApproximateReceiveCount
+    :attributes (:attributes message)
+    ;; the message body itself. If this was the message from SNS it is wrapped in an SNS envelope unless RawMessageDelivery is set to true
+    :message-body (:body message)
+    ;; map of any message attributes set via the SQS send-message API
+    :message-attributes (core/parse-message-attributes (:message-attributes message))
+    ;; the sqs delete message API call pre-bound to the given message/aws config
+    :delete-message #(delete-message config (:receipt-handle message))
+    ;; the sqs change message visibility API call pre-bound to the given message/AWS config
+    :change-message-visibility #(change-message-visibility config (:receipt-handle message) %)})
+    ```
+
+    this adds the `:change-message-visibility` function, as well as providing access to both the original message, and the message attributes.
+
+### Added
+
+-   Moved logging to `clojure.tools.logging`
+-   Added `running` function, returned from `create-consumer`
+-   Request all attributes and message attributes by default (customisable via `attribute-names` and `message-attribute-names` options on `create-consumer`)
+
+### Upgrade guide
+
+1. Change the signature of your `process-fn` from
+
+    ```clojure
+    (defn process-fn
+        [message-body]
+        ...)
+    ```
+
+    to
+
+    ```clojure
+    (defn process-fn
+        [{:keys [message-body]}]
+        ...)
+    ```
+
+2. Replace any usage of `queue.paralle/with-decoder` and `queue.sequential/with-decoder` with , either add a json decoder function fo choice or add `org.clojure/data.jso]` to your classpath
+
+    ```clojure
+    :process-fn (-> process
+        (queue.sequential/with-decoder queue.utils/decode-sns-encoded-json)
+        (queue.sequential/with-auto-delete)
+        (queue.sequential/with-error-handling #(prn % "error processing messages")))
+    ```
+
+    to
+
+    ```clojure
+    :process-fn (-> process
+        ;; or (queue.utilsauto-json-decoder json-fn) to use cheshire/jsonista another library
+        (queue.utils/with-decoder (que.utils/auto-json-decoder))
+        (queue.batch/with-auto-delete)
+        (queue.batch/with-error-handling #(prn % "error processing messages")))
+    ```
 
 ## 0.2.0
 
 ### Breaking
 
 Simplifying how to create a consumer. When creating a consumer from the `sequential` namespace it is now no longer required to wrap your processing function with another call to `sequential-process`. This is also true for the `batch` and `parallel` namespaces.
+
+## 0.1.9-SNAPSHOT
+
+### Breaking
+
+-   `core/create-consumer` no longer accepts a variable number of arguments, instead requires an object of options. Other namespaces remain unchanged
+
+### Added
+
+-   parallel processing namespace (using Claypoole)
+
+```
+
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 ## 0.1.9-SNAPSHOT
 
 ### Added
- - parallel processing namespace (using Claypoole)
- 
-### Breaking
- - `core/create-consumer` no longer accepts a variable number of arguments, instead requires an object of options. Other namespaces remain unchanged
 
+-   parallel processing namespace (using Claypoole)
+
+### Breaking
+
+-   `core/create-consumer` no longer accepts a variable number of arguments, instead requires an object of options. Other namespaces remain unchanged
 
 ## 0.2.0
 
 ### Breaking
+
 Simplifying how to create a consumer. When creating a consumer from the `sequential` namespace it is now no longer required to wrap your processing function with another call to `sequential-process`. This is also true for the `batch` and `parallel` namespaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@
     -   `parallel/with-decoder`
     -   `utils/decode-sns-encoded-json`
 
-    Added new decoding utility higher-order functions. These take a `json-fn` which decodes a JSON string as a first argument, or fallback to clojure.data.json if only one argumetn is specified and the clojure.data.json is found on the classpath:
+    Added new decoding utility higher-order functions. These take a `json-fn` which decodes a JSON string as a first argument, or fallback to clojure.data.json if only one argumetn is specified and the `clojure.data.json` is found on the classpath:
 
     -   `utils/sqs-encoded-json-decoder`
     -   `utils/sns-encoded-json-decoder`
     -   `utils/auto-json-decoder`
+
+    These should be used with the new added `utils/with-handler`, which is a simple wrapper for a function which acts on a message and returns the message with some mutation.
 
     The SNS functions additionally take the message attributes from the SNS payload and add them to `message-attributes` (see below).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
-FROM clojure:lein-2.9.0 AS deps
-WORKDIR /srv
-ADD project.clj .
-RUN lein deps
-ADD src src
-ADD test test
+FROM clojure:openjdk-11-lein-2.9.5-slim-buster
 
-FROM clojure:lein-2.9.0 AS builder
 WORKDIR /srv
-COPY --from=deps /srv .
-COPY --from=deps /root/.m2 /root/.m2
-RUN lein uberjar
+
+COPY project.clj .
+RUN lein deps
+COPY src test ./

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are a number of dependencies for the `utils` ns, these should be dev depen
 Both the `utils` and `parallel` have transitive dependencies that are _not_ bundled with this library. If you don't need them, don't declare the dependencies. Be sure to include these dependencies when you do use them:
 
 ```clj
-[org.clojure/data.json "0.2.6"] ;; required by utils
+[org.clojure/data.json "0.2.6"] ;; required by no-args calls to json decoders in utils
 [com.climate/claypoole "1.1.4"] ;; required by parallel
 ```
 
@@ -45,7 +45,7 @@ Some common usage patterns, the usage should be fairly similar:
                                     :max-number-of-messages 5
                                     :shutdown-wait-time-ms 2000
                                     :process-fn (-> process
-                                                    (queue.sequential/with-decoder queue.utils/decode-sns-encoded-json)
+                                                    (queue.sequential/with-decoder (queue.utils/auto-decode-json-message))
                                                     (queue.sequential/with-auto-delete)
                                                     (queue.sequential/with-error-handling #(prn % "error processing message")))))
 
@@ -73,7 +73,7 @@ Some common usage patterns, the usage should be fairly similar:
                                :max-number-of-messages 10 ;; this effectively becomes the maximum batch size
                                :shutdown-wait-time-ms 2000
                                :process-fn (-> process
-                                               (queue.batch/with-decoder queue.utils/decode-sns-encoded-json)
+                                               (queue.batch/with-decoder (queue.utils/auto-decode-json-message))
                                                (queue.batch/with-auto-delete)
                                                (queue.batch/with-error-handling #(prn % "error processing messages")))))
 
@@ -104,7 +104,7 @@ Under the hood messages here are processed using Claypoole's `upmap` which is un
                                   :threadpool-size 3 ;; defaults to 10. Should be smaller than the number of messages that are dequeued from SQS. More will just mean un-used threads
                                   :shutdown-wait-time-ms 2000
                                   :process-fn (-> process
-                                                  (queue.parallel/with-decoder queue.utils/decode-sns-encoded-json)
+                                                  (queue.parallel/with-decoder (queue.utils/auto-decode-json-message))
                                                   (queue.parallel/with-auto-delete)
                                                   (queue.parallel/with-error-handling #(prn % "error processing messages")))))
 
@@ -131,8 +131,6 @@ If you pass `queue-url` then `queue-name` will never be used. If you only pass `
 -   [ ] Choose a license?
 -   [ ] Tests are a bit flaky - sometimes due to timing they fail
 -   [ ] metadata from SQS and SNS is lost during the deserialisation, maybe some of that is needed?
--   [x] Should we be using `pmap` or `map` across message?
--   [ ] Can we lose the dependency on `data.json`?
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Some common usage patterns, the usage should be fairly similar:
                                     :max-number-of-messages 5
                                     :shutdown-wait-time-ms 2000
                                     :process-fn (-> process
-                                                    (queue.utils/with-auto-message-decoder)
+                                                    (queue.utils/with-auto-message-decoder (queue.utils/with-auto-message-decoder))
                                                     ;; optional. If not included, a zero-arg function delete-message is provided to process-fn
                                                     (queue.sequential/with-auto-delete)
                                                     (queue.sequential/with-error-handling #(prn % "error processing message")))))
@@ -75,7 +75,7 @@ Some common usage patterns, the usage should be fairly similar:
                                :max-number-of-messages 10 ;; this effectively becomes the maximum batch size
                                :shutdown-wait-time-ms 2000
                                :process-fn (-> process
-                                               (queue.utils/with-auto-message-decoder)
+                                               (queue.utils/with-handler (queue.utils/with-auto-message-decoder))
                                                (queue.batch/with-auto-delete)
                                                (queue.batch/with-error-handling #(prn % "error processing messages")))))
 
@@ -107,7 +107,7 @@ Under the hood messages here are processed using Claypoole's `upmap` which is un
                                   :threadpool-size 3 ;; defaults to 10. Should be smaller than the number of messages that are dequeued from SQS. More will just mean un-used threads
                                   :shutdown-wait-time-ms 2000
                                   :process-fn (-> process
-                                                  (queue.utils/with-auto-message-decoder)
+                                                  (queue.utils/with-handler (queue.utils/with-auto-message-decoder))
                                                   ;; optional. If not included, a zero-arg function delete-message is provided to process-fn
                                                   (queue.parallel/with-auto-delete)
                                                   (queue.parallel/with-error-handling #(prn % "error processing messages")))))
@@ -139,7 +139,7 @@ To use [jsonista](https://github.com/metosin/jsonista), construct the decoder wi
 ```clojure
 (require '[jsonista.core :as j])
 
-(queue.utils/with-auto-message-decoder #(j/read-value % j/keyword-keys-object-mapper)))
+(queue.utils/with-handler (queue.utils/with-auto-message-decoder #(j/read-value % j/keyword-keys-object-mapper))))
 ```
 
 To use [cheshire](https://github.com/dakrone/cheshire):
@@ -147,7 +147,7 @@ To use [cheshire](https://github.com/dakrone/cheshire):
 ```clojure
 (require '[cheshire.core :as json])
 
-(queue.utils/with-auto-message-decoder #(json/parse-string % true))
+(queue.utils/with-handler (queue.utils/with-auto-message-decoder #(json/parse-string % true)))
 ```
 
 ### Queue URL vs Queue Name

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Some common usage patterns, the usage should be fairly similar:
                                     :max-number-of-messages 5
                                     :shutdown-wait-time-ms 2000
                                     :process-fn (-> process
-                                                    (queue.sequential/with-decoder (queue.utils/auto-decode-json-message))
+                                                    (queue.utils/with-auto-message-decoder)
                                                     ;; optional. If not included, a zero-arg function delete-message is provided to process-fn
                                                     (queue.sequential/with-auto-delete)
                                                     (queue.sequential/with-error-handling #(prn % "error processing message")))))
@@ -75,7 +75,7 @@ Some common usage patterns, the usage should be fairly similar:
                                :max-number-of-messages 10 ;; this effectively becomes the maximum batch size
                                :shutdown-wait-time-ms 2000
                                :process-fn (-> process
-                                               (queue.batch/with-decoder (queue.utils/auto-decode-json-message))
+                                               (queue.utils/with-auto-message-decoder)
                                                (queue.batch/with-auto-delete)
                                                (queue.batch/with-error-handling #(prn % "error processing messages")))))
 
@@ -107,7 +107,7 @@ Under the hood messages here are processed using Claypoole's `upmap` which is un
                                   :threadpool-size 3 ;; defaults to 10. Should be smaller than the number of messages that are dequeued from SQS. More will just mean un-used threads
                                   :shutdown-wait-time-ms 2000
                                   :process-fn (-> process
-                                                  (queue.parallel/with-decoder (queue.utils/auto-decode-json-message))
+                                                  (queue.utils/with-auto-message-decoder)
                                                   ;; optional. If not included, a zero-arg function delete-message is provided to process-fn
                                                   (queue.parallel/with-auto-delete)
                                                   (queue.parallel/with-error-handling #(prn % "error processing messages")))))
@@ -126,9 +126,9 @@ Under the hood messages here are processed using Claypoole's `upmap` which is un
 
 The higher-order utility functions
 
--   `(queue.utils/auto-decode-json-message)`
--   `(queue.utils/decode-sns-encoded-json)`
--   `(queue.utils/decode-sqs-encoded-json)`
+-   `(queue.utils/with-auto-json-decoder)`
+-   `(queue.utils/with-sns-encoded-json-decoder)`
+-   `(queue.utils/with-sqs-encoded-json-decoder)`
 
 all take a `json-fn` argument which can be used to customise the JSON decoding.
 
@@ -139,7 +139,7 @@ To use [jsonista](https://github.com/metosin/jsonista), construct the decoder wi
 ```clojure
 (require '[jsonista.core :as j])
 
-(queue.utils/auto-decode-json-message #(j/read-value % j/keyword-keys-object-mapper)))
+(queue.utils/with-auto-message-decoder #(j/read-value % j/keyword-keys-object-mapper)))
 ```
 
 To use [cheshire](https://github.com/dakrone/cheshire):
@@ -147,7 +147,7 @@ To use [cheshire](https://github.com/dakrone/cheshire):
 ```clojure
 (require '[cheshire.core :as json])
 
-(queue.utils/auto-decode-json-message #(json/parse-string % true))
+(queue.utils/with-auto-message-decoder #(json/parse-string % true))
 ```
 
 ### Queue URL vs Queue Name
@@ -180,7 +180,7 @@ docker-compose build && docker-compose run --rm sqs_consumer lein test
 
 ## License
 
-Copyright © 2019 Signal AI
+Copyright © 2020 Signal AI
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3.4'
+
 services:
   sqs_consumer:
     build:
@@ -11,6 +12,7 @@ services:
       AWS_SECRET_ACCESS_KEY: "doesnotmatter"
     depends_on:
       - localstack
+
   localstack:
     image: localstack/localstack:0.11.2
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,22 +7,16 @@ services:
       target: deps
     command: lein test
     environment:
-      AWS_DEFAULT_REGION: "eu-west-1"
-      AWS_ACCESS_KEY_ID: "doesnotmatter"
-      AWS_SECRET_ACCESS_KEY: "doesnotmatter"
+      LOCALSTACK_HOST: localstack
     depends_on:
       - localstack
 
   localstack:
-    image: localstack/localstack:0.11.2
+    image: localstack/localstack:0.12.6
     ports:
-      - "8080:8080"
       - "4566:4566"
     environment:
       HOSTNAME: "${LOCALSTACK_HOSTNAME:-localstack}"
       HOSTNAME_EXTERNAL: "${LOCALSTACK_HOSTNAME_EXTERNAL:-localstack}"
       DEFAULT_REGION: "eu-west-1"
       SERVICES: "s3,sqs,sns"
-      AWS_DEFAULT_REGION: "eu-west-1"
-      AWS_ACCESS_KEY_ID: "doesnotmatter"
-      AWS_SECRET_ACCESS_KEY: "doesnotmatter"

--- a/project.clj
+++ b/project.clj
@@ -8,10 +8,19 @@
                  [org.clojure/tools.logging "1.1.0"]
                  [com.clojure-goes-fast/lazy-require "0.1.1"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.2"]
+
                                   [org.clojure/data.json "0.2.6"]
                                   [metosin/jsonista "0.3.1"]
                                   [com.climate/claypoole "1.1.4"]
-                                  [greenpowermonitor/test-doubles "0.1.2"]]}}
+
+                                  ;; testing deps
+                                  [greenpowermonitor/test-doubles "0.1.2"]
+
+                                  [lambdaisland/kaocha "1.0.732"]
+                                  [lambdaisland/kaocha-junit-xml "0.0.76"]
+                                  [lambdaisland/kaocha-cloverage "1.0.75"]]}
+             :test {:env {:localstack-host "localhost"}}}
+  :aliases {"test" ["with-profile" "dev,test" "run" "-m" "kaocha.runner"]}
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_username
                                      :password :env/clojars_token

--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,9 @@
                  [com.amazonaws/aws-java-sdk-sqs "1.11.475"]
                  [org.clojure/tools.logging "1.1.0"]
                  [com.clojure-goes-fast/lazy-require "0.1.1"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.2"]
                                   [org.clojure/data.json "0.2.6"]
+                                  [metosin/jsonista "0.3.1"]
                                   [com.climate/claypoole "1.1.4"]
                                   [greenpowermonitor/test-doubles "0.1.2"]]}}
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"

--- a/project.clj
+++ b/project.clj
@@ -3,13 +3,17 @@
   :url "https://github.com/signal-ai/sqs-consumer"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[amazonica "0.3.139" :exclusions [com.amazonaws/aws-java-sdk]]
-                 [com.amazonaws/aws-java-sdk-sqs "1.11.475"]
+  :dependencies [[amazonica "0.3.153" :exclusions [com.fasterxml.jackson.core/jackson-databind
+                                                   com.fasterxml.jackson.core/jackson-core
+                                                   commons-logging
+                                                   com.amazonaws/aws-java-sdk]]
+                 [com.amazonaws/aws-java-sdk-sqs "1.11.964"]
+
                  [org.clojure/tools.logging "1.1.0"]
                  [com.clojure-goes-fast/lazy-require "0.1.1"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.2"]
 
-                                  [org.clojure/data.json "0.2.6"]
+                                  [org.clojure/data.json "1.0.0"]
                                   [metosin/jsonista "0.3.1"]
                                   [com.climate/claypoole "1.1.4"]
 

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[amazonica "0.3.139" :exclusions [com.amazonaws/aws-java-sdk]]
-                 [com.amazonaws/aws-java-sdk-sqs "1.11.475"]]
+                 [com.amazonaws/aws-java-sdk-sqs "1.11.475"]
+                 [org.clojure/tools.logging "1.1.0"]
+                 [com.clojure-goes-fast/lazy-require "0.1.1"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/data.json "0.2.6"]
                                   [com.climate/claypoole "1.1.4"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.signal-ai/sqs-consumer "0.2.1-SNAPSHOT"
+(defproject com.signal-ai/sqs-consumer "0.3.0"
   :description "Another SQS Library"
   :url "https://github.com/signal-ai/sqs-consumer"
   :license {:name "Eclipse Public License"

--- a/src/sqs_consumer/batch.clj
+++ b/src/sqs_consumer/batch.clj
@@ -1,8 +1,7 @@
 (ns sqs-consumer.batch
   (:require [amazonica.aws.sqs :as sqs]
             [sqs-consumer.core :as core]
-            [sqs-consumer.utils :as utils])
-  (:import [com.amazonaws.services.sqs.model DeleteMessageBatchRequestEntry]))
+            [sqs-consumer.utils :as utils]))
 
 (defn delete-batch [{:keys [queue-url aws-config]} messages]
   (sqs/delete-message-batch
@@ -12,10 +11,9 @@
 
 (defn batch-process [process-fn]
   (fn [{:keys [config messages]}]
-    (let [{:keys [queue-url aws-config]} config]
-      (process-fn {:messages (map :body messages)
-                   :delete-messages #(delete-batch config messages)
-                   :change-message-visibility (fn [visibility])}))))
+    (process-fn {:messages (map :body messages)
+                 :delete-messages #(delete-batch config messages)
+                 :change-message-visibility (fn [_])})))
 
 (defn with-auto-delete [process-fn]
   (fn [{:keys [delete-messages] :as batch}]

--- a/src/sqs_consumer/batch.clj
+++ b/src/sqs_consumer/batch.clj
@@ -1,7 +1,9 @@
 (ns sqs-consumer.batch
   (:require [amazonica.aws.sqs :as sqs]
             [sqs-consumer.core :as core]
-            [sqs-consumer.utils :as utils]))
+            [sqs-consumer.sequential :as sequential]))
+
+(set! *warn-on-reflection* true)
 
 (defn delete-batch [{:keys [queue-url aws-config]} messages]
   (sqs/delete-message-batch
@@ -11,7 +13,8 @@
 
 (defn batch-process [process-fn]
   (fn [{:keys [config messages]}]
-    (process-fn {:messages (map :body messages)
+    (process-fn {;; TODO: pass through non-body
+                 :messages (map :body messages)
                  :delete-messages #(delete-batch config messages)
                  :change-message-visibility (fn [_])})))
 
@@ -22,9 +25,10 @@
 
 (defn with-decoder [process-fn decoder]
   (fn [{:keys [messages]}]
-    (process-fn (doall (map decoder messages)))))
+    (process-fn (doall (map #(:message-body (decoder %)) messages)))))
 
-(def with-error-handling utils/with-error-handler)
+(def with-error-handling sequential/with-error-handling)
+
 ;; TODO: this should also wrap `batch-process`
 (defn create-consumer [& {:keys [process-fn] :as args}]
   (core/create-consumer (merge args {:process-fn (batch-process process-fn)})))

--- a/src/sqs_consumer/core.clj
+++ b/src/sqs_consumer/core.clj
@@ -4,9 +4,11 @@
 
 (set! *warn-on-reflection* true)
 
-(defn dequeue [{:keys [queue-url wait-time-seconds max-number-of-messages aws-config visibility-timeout] :as config} f]
+(defn dequeue [{:keys [attribute-names message-attribute-names queue-url wait-time-seconds max-number-of-messages aws-config visibility-timeout] :as config} f]
   (when-let [msgs (-> (sqs/receive-message aws-config
                                            :queue-url queue-url
+                                           :attribute-names attribute-names
+                                           :message-attribute-names message-attribute-names
                                            :wait-time-seconds wait-time-seconds
                                            :max-number-of-messages max-number-of-messages
                                            :visibility-timeout visibility-timeout)
@@ -39,6 +41,8 @@
    Defaults to sleeping 1 second on exceptions."
   [{:keys [queue-url
            queue-name
+           attribute-names
+           message-attribute-names
            max-number-of-messages
            wait-time-seconds
            shutdown-wait-time-ms
@@ -48,7 +52,9 @@
            run-dequeue-fn
            thread-pool ; optional. Only present during parallel processing
            ]
-    :or {shutdown-wait-time-ms 2000
+    :or {attribute-names ["All"]
+         message-attribute-names ["All"]
+         shutdown-wait-time-ms 2000
          wait-time-seconds 10
          visibility-timeout 60
          run-dequeue-fn default-top-level-error-handler
@@ -56,6 +62,8 @@
   ;; TODO: validate parameters
   (let [queue-url (or queue-url (get-queue-url aws-config queue-name))
         config {:queue-url queue-url
+                :attribute-names attribute-names
+                :message-attribute-names message-attribute-names
                 :max-number-of-messages max-number-of-messages
                 :wait-time-seconds wait-time-seconds
                 :shutdown-wait-time-ms shutdown-wait-time-ms

--- a/src/sqs_consumer/core.clj
+++ b/src/sqs_consumer/core.clj
@@ -54,7 +54,7 @@
                 :visibility-timeout visibility-timeout
                 :thread-pool thread-pool}]
     (when (nil? queue-url)
-      (throw (new IllegalArgumentException "Queue URL or Queue Name must be provided")))
+      (throw (new IllegalArgumentException "Queue URL (:queue-url) or Queue Name (:queue-name) must be provided")))
     {:config config
      :start-consumer (fn []
                        (reset! (:running config) true)
@@ -69,4 +69,5 @@
                         (when (and (not @(:finished-shutdown config)) ; consumer hasn't shutdown gracefully yet
                                    (pos? shutdown-time))              ; and we can still wait longer
                           (Thread/sleep 100)
-                          (recur (- shutdown-time 100)))))}))
+                          (recur (- shutdown-time 100)))))
+     :running (fn [] (and (not @(:running config)) @(:finished-shutdown config)))}))

--- a/src/sqs_consumer/parallel.clj
+++ b/src/sqs_consumer/parallel.clj
@@ -14,8 +14,6 @@
 
 (def with-auto-delete sequential/with-auto-delete)
 
-(def with-decoder sequential/with-decoder)
-
 (def with-error-handling sequential/with-error-handling)
 
 (defn create-consumer [& {:keys [threadpool-size process-fn]

--- a/src/sqs_consumer/parallel.clj
+++ b/src/sqs_consumer/parallel.clj
@@ -1,6 +1,5 @@
 (ns sqs-consumer.parallel
-  (:require [amazonica.aws.sqs :as sqs]
-            [com.climate.claypoole :as cp]
+  (:require [com.climate.claypoole :as cp]
             [sqs-consumer.core :as core]
             [sqs-consumer.utils :as utils]
             [sqs-consumer.sequential :as sequential]))

--- a/src/sqs_consumer/parallel.clj
+++ b/src/sqs_consumer/parallel.clj
@@ -1,24 +1,25 @@
 (ns sqs-consumer.parallel
   (:require [com.climate.claypoole :as cp]
             [sqs-consumer.core :as core]
-            [sqs-consumer.utils :as utils]
             [sqs-consumer.sequential :as sequential]))
+
+(set! *warn-on-reflection* true)
 
 (defn parallel-process [process-fn]
   (fn [{:keys [config messages]}]
     (cp/upmap
      (:thread-pool config)
-     (fn [message] (process-fn {:message-body (:body message)
-                                :delete-message #(sequential/delete-message config (:receipt-handle message))}))
+     (fn [message] (process-fn (sequential/extract-message config message)))
      messages)))
 
 (def with-auto-delete sequential/with-auto-delete)
 
 (def with-decoder sequential/with-decoder)
 
-(def with-error-handling utils/with-error-handler)
+(def with-error-handling sequential/with-error-handling)
 
-(defn create-consumer [& {:keys [threadpool-size process-fn] :or {threadpool-size 10} :as args}]
+(defn create-consumer [& {:keys [threadpool-size process-fn]
+                          :or {threadpool-size 10} :as args}]
   (let [thread-pool (cp/threadpool threadpool-size)
         consumer (core/create-consumer (merge args {:thread-pool thread-pool :process-fn (parallel-process process-fn)}))]
     (-> consumer

--- a/src/sqs_consumer/sequential.clj
+++ b/src/sqs_consumer/sequential.clj
@@ -41,14 +41,6 @@
     (when (process-fn (dissoc message :delete-message))
       (delete-message))))
 
-(defn with-decoder
-  "Merges the message with the result of the given message decoder. The decoder is called with the :message-body from the extract-message function."
-  [process-fn decoder]
-  (fn [message]
-    (-> message
-        (merge (decoder (:message-body message)))
-        process-fn)))
-
 (defn with-error-handling
   "Calls the given error handler when any error occurs further down the handler stack."
   [process-fn error-handler]

--- a/src/sqs_consumer/sequential.clj
+++ b/src/sqs_consumer/sequential.clj
@@ -25,8 +25,10 @@
    :message-attributes (core/parse-message-attributes (:message-attributes message))
    ;; the sqs delete message API call pre-bound to the given message/aws config
    :delete-message #(delete-message config (:receipt-handle message))
-    ;; the sqs change message visibility API call pre-bound to the given message/AWS config
-   :change-message-visibility #(change-message-visibility config (:receipt-handle message) %)})
+   ;; the sqs change message visibility API call pre-bound to the given message/AWS config
+   :change-message-visibility #(change-message-visibility config (:receipt-handle message) %)
+   ;; config for the sqs-consumer
+   ::core/config config})
 
 (defn sequential-process [process-fn]
   (fn [{:keys [config messages]}]

--- a/src/sqs_consumer/sequential.clj
+++ b/src/sqs_consumer/sequential.clj
@@ -1,27 +1,63 @@
 (ns sqs-consumer.sequential
   (:require [amazonica.aws.sqs :as sqs]
-            [sqs-consumer.core :as core]
-            [sqs-consumer.utils :as utils]))
+            [sqs-consumer.core :as core]))
 
-(defn delete-message [{:keys [queue-url aws-config]} receipt-handle]
+(set! *warn-on-reflection* true)
+
+(defn- delete-message [{:keys [queue-url aws-config]} receipt-handle]
   (sqs/delete-message aws-config queue-url receipt-handle))
+
+(defn- change-message-visibility [{:keys [queue-url aws-config]} receipt-handle visibility-timeout]
+  (sqs/change-message-visibility aws-config queue-url receipt-handle visibility-timeout))
+
+(defn extract-message
+  "Extracts the message from the SQS receive messages response.
+   
+   Each message is an SQS Message https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/index.html?com/amazonaws/services/sqs/model/Message.html."
+  [config message]
+  {;; the original message, with unparsed body.
+   :message message
+   ;; attributes on the message, note these are different to message-attributes, e.g. ApproximateReceiveCount
+   :attributes (:attributes message)
+   ;; the message body itself. If this was the message from SNS it is wrapped in an SNS envelope unless RawMessageDelivery is set to true
+   :message-body (:body message)
+   ;; map of any message attributes set via the SQS send-message API
+   :message-attributes (core/parse-message-attributes (:message-attributes message))
+   ;; the sqs delete message API call pre-bound to the given message/aws config
+   :delete-message #(delete-message config (:receipt-handle message))
+    ;; the sqs change message visibility API call pre-bound to the given message/AWS config
+   :change-message-visibility #(change-message-visibility config (:receipt-handle message) %)})
 
 (defn sequential-process [process-fn]
   (fn [{:keys [config messages]}]
-    (run! (fn [message] (process-fn {:message-body (:body message)
-                                     :delete-message #(delete-message config (:receipt-handle message))}))
+    (run! (fn [message] (process-fn (extract-message config message)))
           messages)))
 
-(defn with-auto-delete [process-fn]
+(defn with-auto-delete
+  "Auto deletes the message from SQS whenever process-fn returns a truthy value.
+   If a non-truthy value is returned or an exception is thrown the message will not be deleted."
+  [process-fn]
   (fn [{:keys [delete-message] :as message}]
     (when (process-fn (dissoc message :delete-message))
       (delete-message))))
 
-(defn with-decoder [process-fn decoder]
-  (fn [{:keys [message]}]
-    (process-fn (decoder message))))
+(defn with-decoder
+  "Merges the message with the result of the given message decoder. The decoder is called with the :message-body from the extract-message function."
+  [process-fn decoder]
+  (fn [message]
+    (-> message
+        (merge (decoder (:message-body message)))
+        process-fn)))
 
-(def with-error-handling utils/with-error-handler)
+(defn with-error-handling
+  "Calls the given error handler when any error occurs further down the handler stack."
+  [process-fn error-handler]
+  (fn [message]
+    (try
+      (process-fn message)
+      (catch Exception ex
+        (error-handler ex)))))
+
 ;; TODO: this should also wrap `sequential-process`
 (defn create-consumer [& {:keys [process-fn] :as args}]
   (core/create-consumer (merge args {:process-fn (sequential-process process-fn)})))

--- a/src/sqs_consumer/utils.clj
+++ b/src/sqs_consumer/utils.clj
@@ -85,10 +85,11 @@
   ([]
    (auto-json-decoder (lazy-load-data-json))))
 
-(defn with-decoder
-  [process-fn decoder]
+(defn with-handler
+  "Calls the given handler and passes it down the chain. Useful when threading a process-fn."
+  [process-fn handler]
   (fn [message]
-    (process-fn (decoder message))))
+    (process-fn (handler message))))
 
 (defn uuid
   "Generates a V4 UUID and converts it to a string."

--- a/src/sqs_consumer/utils.clj
+++ b/src/sqs_consumer/utils.clj
@@ -1,27 +1,81 @@
 (ns sqs-consumer.utils
-  (:require [clojure.data.json :as json]
-            [amazonica.aws.sqs :as sqs]))
+  (:require [clojure.tools.logging :as log]
+            [lazy-require.core :as lreq]))
 
-(defn add-timestamp [message outer-message]
-  "Add timestamp from the SNS metadata if it doesn't already exist"
+(defn add-timestamp
+  "Add timestamp from the SNS metadata if it doesn't already exist."
+  [message outer-message]
   (if (:timestamp message)
     message
     (assoc message :timestamp (:Timestamp outer-message))))
 
-(defn decode-sns-encoded-json [message-body]
-  (let [outer-message (json/read-str message-body :key-fn keyword)]
-    (-> outer-message
-        :Message
-        (json/read-str :key-fn keyword)
-        (add-timestamp outer-message))))
+(defn- lazy-load-data-json []
+  (try
+    (lreq/with-lazy-require '[clojure.data.json :as json]
+      #(clojure.data.json/read-str % :key-fn keyword))
+    (catch Throwable e
+      (log/error e "decoder called with no json-fn and without clojure.data.json on the classpath. Please either add clojure.data.json or provide a json-fn.")
+      (throw e))))
 
-(defn with-message-decoder [process-fn decoder]
+(defn decode-sns-encoded-json
+  "Returns a decoder which decodes the external SNS message and the internal \"Message\" property on the message in-place.
+   
+   If no json-fn is provided, will load clojure.data.json."
+  ([json-fn]
+   (fn [message-body]
+     (let [outer-message (json-fn message-body)]
+       (-> outer-message
+           :Message
+           (json-fn)
+           (add-timestamp outer-message)))))
+  ([]
+   (decode-sns-encoded-json (lazy-load-data-json))))
+
+
+(defn decode-sqs-encoded-json
+  "Returns a decoder which internal message in-place.
+   
+   If no json-fn is provided, will load clojure.data.json."
+  ([json-fn]
+   (fn [message-body]
+     (-> message-body
+         :Message
+         (json-fn))))
+  ([]
+   (decode-sns-encoded-json (lazy-load-data-json))))
+
+(defn auto-decode-json-message
+  "Returns a decoder determines whether the message was from SQS or SNS and decodes the message appropriately.
+   
+   Adds :sqs-consumer/metadata :message-envelope as :sqs or :sns to the decoded message for use by downstream handlers.
+  
+   If no json-fn is provided, will load clojure.data.json."
+  ([json-fn]
+   (let [decode-sns (decode-sns-encoded-json json-fn)
+         decode-sqs (decode-sqs-encoded-json json-fn)]
+     (fn [message-body]
+       (cond
+         (contains? message-body :Type) (do (log/debug "Decoding message from SQS")
+                                            (-> (decode-sqs)
+                                                (assoc-in [:sqs-consumer/metadata :message-envelope] :sqs)))
+         :else (do (log/debug "Decoding message from SNS" :sns-message-id (:MessageId message-body))
+                   (-> message-body
+                       (decode-sns)
+                       (assoc-in [:sqs-consumer/metadata :message-envelope] :sns)))))))
+  ([]
+   (auto-decode-json-message (lazy-load-data-json))))
+
+(defn with-message-decoder
+  "Assocs :message with the result of the given message decoder, called with the message body."
+  [process-fn decoder]
   (fn [{:keys [message-body] :as message}]
     (-> message
         (assoc :message (decoder message-body))
         process-fn)))
 
-(defn with-error-handler [process-fn error-handler]
+(defn with-error-handler
+  "Calls the given error handler when any error occurs further down the handler stack."
+  [process-fn error-handler]
   (fn [message]
     (try
       (process-fn message)

--- a/test/sqs_consumer/batch_test.clj
+++ b/test/sqs_consumer/batch_test.clj
@@ -98,7 +98,7 @@
                test-error-handler]
       (let [{:keys [config start-consumer stop-consumer]} (test-consumer
                                                            (-> processing-function
-                                                               (batch/with-decoder identity)
+                                                               (batch/with-decoder #(hash-map :message-body %))
                                                                batch/with-auto-delete
                                                                (batch/with-error-handling test-error-handler)))
             _ (sqs/send-message aws-config
@@ -121,8 +121,8 @@
       :spying [processing-function
                test-error-handler]
       (let [{:keys [config start-consumer stop-consumer]} (test-consumer
-                                                           (-> (fn [batch] (throw (new Exception "testing error handling")))
-                                                               (batch/with-decoder identity)
+                                                           (-> (fn [_] (throw (new Exception "testing error handling")))
+                                                               (batch/with-decoder #(hash-map :message-body %))
                                                                batch/with-auto-delete
                                                                (batch/with-error-handling test-error-handler)))
             _ (sqs/send-message aws-config

--- a/test/sqs_consumer/batch_test.clj
+++ b/test/sqs_consumer/batch_test.clj
@@ -1,10 +1,10 @@
 (ns sqs-consumer.batch-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [sqs-consumer.batch :as batch]
-            [sqs-consumer.core :refer [get-queue-url]]
             [amazonica.aws.sqs :as sqs]
-            [greenpowermonitor.test-doubles :as td])
-  (:import java.io.FileNotFoundException))
+            [greenpowermonitor.test-doubles :as td]
+            [sqs-consumer.core :refer [get-queue-url]]
+            [sqs-consumer.localstack :as localstack]))
 
 (def test-queue-name "batch-test-queue")
 
@@ -15,22 +15,10 @@
 (defn test-error-handler [e]
   (prn e))
 
-(def aws-config {:endpoint "http://localstack:4566"
-                 :client-config {}})
-
-(defn wait-for-localstack []
-  (try
-    (slurp "http://localstack:8080/health")
-    (prn "localstack up")
-    (catch FileNotFoundException _
-      (prn "waiting for localstack")
-      (Thread/sleep 500)
-      (wait-for-localstack))))
-
 (use-fixtures :once (fn [f]
-                      (wait-for-localstack)
+                      (localstack/wait-for-localstack)
                       (sqs/create-queue
-                       aws-config
+                       localstack/aws-config
                        :queue-name test-queue-name
                        :attributes
                        {:VisibilityTimeout 30 ; sec
@@ -39,15 +27,15 @@
                         :ReceiveMessageWaitTimeSeconds 10})
                       (f)
                       (sqs/delete-queue
-                       aws-config
-                       (get-queue-url aws-config test-queue-name))))
+                       localstack/aws-config
+                       (get-queue-url localstack/aws-config test-queue-name))))
 
 (defn test-consumer [process]
   (batch/create-consumer :queue-name test-queue-name
                          :max-number-of-messages 10
                          :shutdown-wait-time-ms 1500
                          :wait-time-seconds 1
-                         :aws-config aws-config
+                         :aws-config localstack/aws-config
                          :process-fn process))
 
 (deftest batch-consumer-test
@@ -57,11 +45,11 @@
                test-error-handler]
       (let [{:keys [config start-consumer stop-consumer]} (test-consumer (-> processing-function
                                                                              (batch/with-error-handling test-error-handler)))
-            _ (sqs/send-message aws-config
-                                :queue-url (get-queue-url aws-config test-queue-name)
+            _ (sqs/send-message localstack/aws-config
+                                :queue-url (get-queue-url localstack/aws-config test-queue-name)
                                 :message-body "hello world")
-            _ (sqs/send-message aws-config
-                                :queue-url (get-queue-url aws-config test-queue-name)
+            _ (sqs/send-message localstack/aws-config
+                                :queue-url (get-queue-url localstack/aws-config test-queue-name)
                                 :message-body "hello world")
             consumer (future (start-consumer))]
         (is (not (nil? consumer)))
@@ -78,11 +66,11 @@
                                                            (-> processing-function
                                                                batch/with-auto-delete
                                                                (batch/with-error-handling test-error-handler)))
-            _ (sqs/send-message aws-config
-                                :queue-url (get-queue-url aws-config test-queue-name)
+            _ (sqs/send-message localstack/aws-config
+                                :queue-url (get-queue-url localstack/aws-config test-queue-name)
                                 :message-body "hello world 1")
-            _ (sqs/send-message aws-config
-                                :queue-url (get-queue-url aws-config test-queue-name)
+            _ (sqs/send-message localstack/aws-config
+                                :queue-url (get-queue-url localstack/aws-config test-queue-name)
                                 :message-body "hello world 2")
 
             consumer (future (start-consumer))]
@@ -101,11 +89,11 @@
                                                                (batch/with-decoder #(hash-map :message-body %))
                                                                batch/with-auto-delete
                                                                (batch/with-error-handling test-error-handler)))
-            _ (sqs/send-message aws-config
-                                :queue-url (get-queue-url aws-config test-queue-name)
+            _ (sqs/send-message localstack/aws-config
+                                :queue-url (get-queue-url localstack/aws-config test-queue-name)
                                 :message-body "hello world 1")
-            _ (sqs/send-message aws-config
-                                :queue-url (get-queue-url aws-config test-queue-name)
+            _ (sqs/send-message localstack/aws-config
+                                :queue-url (get-queue-url localstack/aws-config test-queue-name)
                                 :message-body "hello world 2")
 
             consumer (future (start-consumer))]
@@ -125,11 +113,11 @@
                                                                (batch/with-decoder #(hash-map :message-body %))
                                                                batch/with-auto-delete
                                                                (batch/with-error-handling test-error-handler)))
-            _ (sqs/send-message aws-config
-                                :queue-url (get-queue-url aws-config test-queue-name)
+            _ (sqs/send-message localstack/aws-config
+                                :queue-url (get-queue-url localstack/aws-config test-queue-name)
                                 :message-body "hello world")
-            _ (sqs/send-message aws-config
-                                :queue-url (get-queue-url aws-config test-queue-name)
+            _ (sqs/send-message localstack/aws-config
+                                :queue-url (get-queue-url localstack/aws-config test-queue-name)
                                 :message-body "hello world")
 
             consumer (future (start-consumer))]
@@ -148,11 +136,11 @@
                                                                (batch/with-decoder (fn [_] (throw (new Exception "unable to decode message"))))
                                                                batch/with-auto-delete
                                                                (batch/with-error-handling test-error-handler)))
-            _ (sqs/send-message aws-config
-                                :queue-url (get-queue-url aws-config test-queue-name)
+            _ (sqs/send-message localstack/aws-config
+                                :queue-url (get-queue-url localstack/aws-config test-queue-name)
                                 :message-body "hello world")
-            _ (sqs/send-message aws-config
-                                :queue-url (get-queue-url aws-config test-queue-name)
+            _ (sqs/send-message localstack/aws-config
+                                :queue-url (get-queue-url localstack/aws-config test-queue-name)
                                 :message-body "hello world")
 
             consumer (future (start-consumer))]

--- a/test/sqs_consumer/core_test.clj
+++ b/test/sqs_consumer/core_test.clj
@@ -37,18 +37,22 @@
                        aws-config
                        (get-queue-url aws-config test-queue-name))))
 
-(defn test-consumer []
-  (create-consumer {:queue-name test-queue-name
-                    :max-number-of-messages 5
-                    :shutdown-wait-time-ms 1500
-                    :wait-time-seconds 1
-                    :aws-config aws-config
-                    :process-fn processing-function}))
+(defn test-consumer
+  ([process-fn]
+   (create-consumer {:queue-name test-queue-name
+                     :max-number-of-messages 5
+                     :shutdown-wait-time-ms 1500
+                     :wait-time-seconds 1
+                     :aws-config aws-config
+                     :process-fn process-fn}))
+  ([]
+   (test-consumer processing-function)))
 
 (deftest basic-consumer-test
   (testing "can create the consumer"
     (let [{:keys [start-consumer]} (test-consumer)]
       (is (not (nil? start-consumer)))))
+
   (testing "can start the consumer"
     (let [{:keys [config start-consumer stop-consumer]} (test-consumer)
           consumer (future (start-consumer))]
@@ -56,6 +60,7 @@
       (is (nil? (stop-consumer)))
       (Thread/sleep 2000)
       (is (true? @(:finished-shutdown config)))))
+
   (testing "can receive a message"
     (td/with-doubles
       :spying [processing-function]

--- a/test/sqs_consumer/core_test.clj
+++ b/test/sqs_consumer/core_test.clj
@@ -1,13 +1,13 @@
 (ns sqs-consumer.core-test
-  (:require [clojure.test :refer :all]
-            [sqs-consumer.core :refer :all]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [sqs-consumer.core :refer [create-consumer get-queue-url]]
             [amazonica.aws.sqs :as sqs]
             [greenpowermonitor.test-doubles :as td])
   (:import java.io.FileNotFoundException))
 
 (def test-queue-name "test-queue")
 
-(defn processing-function [a]
+(defn processing-function [_]
   (prn "calling function"))
 
 (def aws-config {:endpoint "http://localstack:4566"
@@ -47,7 +47,7 @@
 
 (deftest basic-consumer-test
   (testing "can create the consumer"
-    (let [{:keys [start-consumer stop-consumer]} (test-consumer)]
+    (let [{:keys [start-consumer]} (test-consumer)]
       (is (not (nil? start-consumer)))))
   (testing "can start the consumer"
     (let [{:keys [config start-consumer stop-consumer]} (test-consumer)
@@ -68,5 +68,4 @@
         ;; expect here that we get a batch of messages as we don't fan out
         (is (= 1 (-> processing-function td/calls-to count)))
         (is (nil? (stop-consumer)))
-        (is (true? @(:finished-shutdown config)))
-        ))))
+        (is (true? @(:finished-shutdown config)))))))

--- a/test/sqs_consumer/localstack.clj
+++ b/test/sqs_consumer/localstack.clj
@@ -1,0 +1,29 @@
+(ns sqs-consumer.localstack
+  (:require [clojure.tools.logging :as log]))
+
+(def ^:private localstack-host
+  (or (System/getenv "LOCALSTACK_HOST")
+      "localhost"))
+
+(def aws-config {:access-key "localstack"
+                 :secret-key "localstack"
+                 :endpoint (format "http://%s:4566" localstack-host)
+                 :client-config {}})
+
+(defn wait-for-localstack []
+  (let [localstack-url (format "http://%s:4566/health" localstack-host)
+        localstack-retry-count (atom 0)]
+    (log/infof "looking up localstack at %s" localstack-url)
+    (try
+      (slurp localstack-url)
+      (log/infof "localstack ready at %s" localstack-url)
+      (catch Exception e
+        (if (>= @localstack-retry-count 20)
+          (do
+            (log/fatalf "retry limit reached waiting for localstack at %s, %s" localstack-url)
+            (System/exit 1))
+          (do
+            (swap! localstack-retry-count inc)
+            (log/infof "waiting for localstack at %s, %s" localstack-url (.getMessage e))
+            (Thread/sleep 500)
+            (wait-for-localstack)))))))

--- a/test/sqs_consumer/parallel_test.clj
+++ b/test/sqs_consumer/parallel_test.clj
@@ -1,32 +1,20 @@
 (ns sqs-consumer.parallel-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [amazonica.aws.sqs :as sqs]
+            [greenpowermonitor.test-doubles :as td]
             [sqs-consumer.core :refer [get-queue-url]]
             [sqs-consumer.parallel :as parallel]
-            [amazonica.aws.sqs :as sqs]
-            [greenpowermonitor.test-doubles :as td])
-  (:import java.io.FileNotFoundException))
+            [sqs-consumer.localstack :as localstack]))
 
 (def test-queue-name "parallel-test-queue")
 
 (defn processing-function [_]
   (prn "calling function"))
 
-(def aws-config {:endpoint "http://localstack:4566"
-                 :client-config {}})
-
-(defn wait-for-localstack []
-  (try
-    (slurp "http://localstack:8080/health")
-    (prn "localstack up")
-    (catch FileNotFoundException _
-      (prn "waiting for localstack")
-      (Thread/sleep 500)
-      (wait-for-localstack))))
-
 (use-fixtures :once (fn [f]
-                      (wait-for-localstack)
+                      (localstack/wait-for-localstack)
                       (sqs/create-queue
-                       aws-config
+                       localstack/aws-config
                        :queue-name test-queue-name
                        :attributes
                        {:VisibilityTimeout 300 ; sec
@@ -35,15 +23,15 @@
                         :ReceiveMessageWaitTimeSeconds 10})
                       (f)
                       (sqs/delete-queue
-                       aws-config
-                       (get-queue-url aws-config test-queue-name))))
+                       localstack/aws-config
+                       (get-queue-url localstack/aws-config test-queue-name))))
 
 (defn test-consumer [process]
   (parallel/create-consumer :queue-name test-queue-name
                             :max-number-of-messages 5
                             :shutdown-wait-time-ms 1500
                             :wait-time-seconds 1
-                            :aws-config aws-config
+                            :aws-config localstack/aws-config
                             :process-fn process))
 
 (defn just-the-body [process-fn]
@@ -68,8 +56,8 @@
       :spying [processing-function]
       (let [{:keys [config start-consumer stop-consumer]} (test-consumer (-> processing-function
                                                                              just-the-body))
-            _ (sqs/send-message aws-config :queue-url (get-queue-url aws-config test-queue-name) :message-body "hello world 1")
-            _ (sqs/send-message aws-config :queue-url (get-queue-url aws-config test-queue-name) :message-body "hello world 2")
+            _ (sqs/send-message localstack/aws-config :queue-url (get-queue-url localstack/aws-config test-queue-name) :message-body "hello world 1")
+            _ (sqs/send-message localstack/aws-config :queue-url (get-queue-url localstack/aws-config test-queue-name) :message-body "hello world 2")
             consumer (future (start-consumer))]
         (is (not (nil? consumer)))
         (Thread/sleep 100)
@@ -85,8 +73,8 @@
       (let [{:keys [config start-consumer stop-consumer]} (test-consumer (-> processing-function
                                                                              just-the-body
                                                                              parallel/with-auto-delete))
-            _ (sqs/send-message aws-config :queue-url (get-queue-url aws-config test-queue-name) :message-body "hello world 1")
-            _ (sqs/send-message aws-config :queue-url (get-queue-url aws-config test-queue-name) :message-body "hello world 2")
+            _ (sqs/send-message localstack/aws-config :queue-url (get-queue-url localstack/aws-config test-queue-name) :message-body "hello world 1")
+            _ (sqs/send-message localstack/aws-config :queue-url (get-queue-url localstack/aws-config test-queue-name) :message-body "hello world 2")
             _ (Thread/sleep 100)
             consumer (future (start-consumer))]
         (is (not (nil? consumer)))

--- a/test/sqs_consumer/parallel_test.clj
+++ b/test/sqs_consumer/parallel_test.clj
@@ -54,6 +54,7 @@
   (testing "can create the consumer"
     (let [{:keys [start-consumer]} (test-consumer processing-function)]
       (is (not (nil? start-consumer)))))
+
   (testing "can start the consumer"
     (let [{:keys [config start-consumer stop-consumer]} (test-consumer processing-function)
           consumer (future (start-consumer))]
@@ -61,6 +62,7 @@
       (is (nil? (stop-consumer)))
       (Thread/sleep 2000)
       (is (true? @(:finished-shutdown config)))))
+
   (testing "can receive messages"
     (td/with-doubles
       :spying [processing-function]

--- a/test/sqs_consumer/parallel_test.clj
+++ b/test/sqs_consumer/parallel_test.clj
@@ -50,7 +50,7 @@
   (fn [{:keys [message-body]}]
     (process-fn message-body)))
 
-(deftest sequential-consumer-test
+(deftest parallel-consumer-test
   (testing "can create the consumer"
     (let [{:keys [start-consumer]} (test-consumer processing-function)]
       (is (not (nil? start-consumer)))))
@@ -71,9 +71,8 @@
             consumer (future (start-consumer))]
         (is (not (nil? consumer)))
         (Thread/sleep 100)
-        ;; expect here that messages are processed one by one, sequentially
         (is (= 2 (-> processing-function td/calls-to count)))
-        (is (= [["hello world 1"] ["hello world 2"]] (td/calls-to processing-function)))
+        (is (= (set [["hello world 1"] ["hello world 2"]]) (set (td/calls-to processing-function))))
         (is (nil? (stop-consumer)))
         (Thread/sleep 100)
         (is (true? @(:finished-shutdown config))))))
@@ -90,9 +89,8 @@
             consumer (future (start-consumer))]
         (is (not (nil? consumer)))
         (Thread/sleep 100)
-        ;; expect here that messages are processed one by one, sequentially
         (is (= 2 (-> processing-function td/calls-to count)))
-        (is (= [["hello world 1"] ["hello world 2"]] (td/calls-to processing-function)))
+        (is (= (set [["hello world 1"] ["hello world 2"]]) (set (td/calls-to processing-function))))
         (is (nil? (stop-consumer)))
         (Thread/sleep 100)
         (is (true? @(:finished-shutdown config)))))))

--- a/test/sqs_consumer/parallel_test.clj
+++ b/test/sqs_consumer/parallel_test.clj
@@ -1,5 +1,5 @@
 (ns sqs-consumer.parallel-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [sqs-consumer.core :refer [get-queue-url]]
             [sqs-consumer.parallel :as parallel]
             [amazonica.aws.sqs :as sqs]
@@ -8,7 +8,7 @@
 
 (def test-queue-name "parallel-test-queue")
 
-(defn processing-function [a]
+(defn processing-function [_]
   (prn "calling function"))
 
 (def aws-config {:endpoint "http://localstack:4566"
@@ -40,11 +40,11 @@
 
 (defn test-consumer [process]
   (parallel/create-consumer :queue-name test-queue-name
-                       :max-number-of-messages 5
-                       :shutdown-wait-time-ms 1500
-                       :wait-time-seconds 1
-                       :aws-config aws-config
-                       :process-fn process))
+                            :max-number-of-messages 5
+                            :shutdown-wait-time-ms 1500
+                            :wait-time-seconds 1
+                            :aws-config aws-config
+                            :process-fn process))
 
 (defn just-the-body [process-fn]
   (fn [{:keys [message-body]}]
@@ -52,7 +52,7 @@
 
 (deftest sequential-consumer-test
   (testing "can create the consumer"
-    (let [{:keys [start-consumer stop-consumer]} (test-consumer processing-function)]
+    (let [{:keys [start-consumer]} (test-consumer processing-function)]
       (is (not (nil? start-consumer)))))
   (testing "can start the consumer"
     (let [{:keys [config start-consumer stop-consumer]} (test-consumer processing-function)
@@ -96,5 +96,3 @@
         (is (nil? (stop-consumer)))
         (Thread/sleep 100)
         (is (true? @(:finished-shutdown config)))))))
-
-

--- a/test/sqs_consumer/seq_test.clj
+++ b/test/sqs_consumer/seq_test.clj
@@ -1,9 +1,9 @@
 (ns sqs-consumer.seq-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [sqs-consumer.core :refer [get-queue-url]]
-            [sqs-consumer.sequential :as seq]
             [amazonica.aws.sqs :as sqs]
-            [greenpowermonitor.test-doubles :as td])
+            [greenpowermonitor.test-doubles :as td]
+            [sqs-consumer.core :refer [get-queue-url]]
+            [sqs-consumer.sequential :as seq])
   (:import java.io.FileNotFoundException))
 
 (def test-queue-name "seq-test-queue")
@@ -54,6 +54,7 @@
   (testing "can create the consumer"
     (let [{:keys [start-consumer]} (test-consumer processing-function)]
       (is (not (nil? start-consumer)))))
+
   (testing "can start the consumer"
     (let [{:keys [config start-consumer stop-consumer]} (test-consumer processing-function)
           consumer (future (start-consumer))]
@@ -61,6 +62,7 @@
       (is (nil? (stop-consumer)))
       (Thread/sleep 2000)
       (is (true? @(:finished-shutdown config)))))
+
   (testing "can receive messages"
     (td/with-doubles
       :spying [processing-function]

--- a/test/sqs_consumer/seq_test.clj
+++ b/test/sqs_consumer/seq_test.clj
@@ -1,5 +1,5 @@
 (ns sqs-consumer.seq-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [sqs-consumer.core :refer [get-queue-url]]
             [sqs-consumer.sequential :as seq]
             [amazonica.aws.sqs :as sqs]
@@ -8,7 +8,7 @@
 
 (def test-queue-name "seq-test-queue")
 
-(defn processing-function [a]
+(defn processing-function [_]
   (prn "calling function"))
 
 (def aws-config {:endpoint "http://localstack:4566"
@@ -52,7 +52,7 @@
 
 (deftest sequential-consumer-test
   (testing "can create the consumer"
-    (let [{:keys [start-consumer stop-consumer]} (test-consumer processing-function)]
+    (let [{:keys [start-consumer]} (test-consumer processing-function)]
       (is (not (nil? start-consumer)))))
   (testing "can start the consumer"
     (let [{:keys [config start-consumer stop-consumer]} (test-consumer processing-function)

--- a/test/sqs_consumer/utils_test.clj
+++ b/test/sqs_consumer/utils_test.clj
@@ -1,6 +1,7 @@
 (ns sqs-consumer.utils-test
   (:require [clojure.test :refer [deftest is]]
             [greenpowermonitor.test-doubles :as td]
+            [sqs-consumer.core :as core]
             [sqs-consumer.sequential :as seq]
             [sqs-consumer.utils :as utils]
             [jsonista.core :as jsonista]))
@@ -30,7 +31,7 @@
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001 :timestamp "2018-04-17T11:33:44.770Z"}
           :message-attributes {:Type "Orchestration.Services.Model.Pollution.PollutionMessage"
                                :AWS.SNS.MOBILE.MPNS.Type "token"}
-          :sqs-consumer/metadata {:message-envelope :sns}}
+          ::core/metadata {:message-envelope :sns}}
          ((utils/auto-json-decoder) (wrapped-message (test-sns-message))))))
 
 (deftest auto-decode-json-message-adds-timestamp-from-sns-message-if-absent
@@ -52,18 +53,18 @@
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001 :timestamp "2018-04-17T11:33:44.770Z"}
           :message-attributes {:Type "Orchestration.Services.Model.Pollution.PollutionMessage"
                                :AWS.SNS.MOBILE.MPNS.Type "token"}
-          :sqs-consumer/metadata {:message-envelope :sns}}
+          ::core/metadata {:message-envelope :sns}}
          ((utils/auto-json-decoder #(jsonista/read-value % jsonista/keyword-keys-object-mapper)) (wrapped-message (test-sns-message))))))
 
 (deftest auto-decode-json-message-decodes-sqs-no-args
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001}
-          :sqs-consumer/metadata {:message-envelope :sqs}}
+          ::core/metadata {:message-envelope :sqs}}
          ((utils/auto-json-decoder)
           (wrapped-message "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}")))))
 
 (deftest auto-decode-json-message-decodes-sqs-jsonista
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001}
-          :sqs-consumer/metadata {:message-envelope :sqs}}
+          ::core/metadata {:message-envelope :sqs}}
          ((utils/auto-json-decoder #(jsonista/read-value % jsonista/keyword-keys-object-mapper))
           (wrapped-message "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}")))))
 
@@ -72,13 +73,13 @@
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001 :timestamp "2018-04-17T11:33:44.770Z"}
           :message-attributes {:Type "Orchestration.Services.Model.Pollution.PollutionMessage"
                                :AWS.SNS.MOBILE.MPNS.Type "token"}
-          :sqs-consumer/metadata {:message-envelope :sns}}
+          ::core/metadata {:message-envelope :sns}}
          ((utils/sns-encoded-json-decoder) (wrapped-message (test-sns-message))))))
 
 
 (deftest sqs-encoded-json-decoder-decodes-sqs-no-args
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001}
-          :sqs-consumer/metadata {:message-envelope :sqs}}
+          ::core/metadata {:message-envelope :sqs}}
          ((utils/sqs-encoded-json-decoder)
           (wrapped-message "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}")))))
 

--- a/test/sqs_consumer/utils_test.clj
+++ b/test/sqs_consumer/utils_test.clj
@@ -85,13 +85,13 @@
 
 (defn processing-function [_])
 
-(deftest with-decoder-passes-through-values-correctly
+(deftest with-handler-passes-through-values-correctly
   (td/with-doubles
     :spying [processing-function]
     (let [message-body {:id "123"
                         :attribute {:sub-attribute true}}
           process-fn (-> processing-function
-                         (utils/with-decoder (utils/auto-json-decoder)))
+                         (utils/with-handler (utils/auto-json-decoder)))
           message {:body (jsonista/write-value-as-string message-body)}
           config {:visibility-timeout 123}]
 

--- a/test/sqs_consumer/utils_test.clj
+++ b/test/sqs_consumer/utils_test.clj
@@ -1,0 +1,16 @@
+(ns sqs-consumer.utils-test
+  (:require [clojure.test :refer [deftest is]]
+            [sqs-consumer.utils :as utils]))
+
+(deftest auto-decode-json-message-decodes-sns
+  (is (= "" ((utils/auto-decode-json-message) "{
+   \"Type\": \"Notification\",
+   \"MessageId\": \"dc1e94d9-56c5-5e96-808d-cc7f68faa162\",
+   \"TopicArn\": \"arn:aws:sns:us-east-2:665242997532:ExampleTopic1\",
+   \"Subject\": \"TestSubject\",
+   \"Message\": \"\",
+   \"Timestamp\": \"2021-02-16T21:41:19.978Z\",
+   \"SignatureVersion\": \"1\",
+   \"Signature\": \"FMG5tlZhJNHLHUXvZgtZzlk24FzVa7oX0T4P03neeXw8ZEXZx6z35j2FOTuNYShn2h0bKNC/zLTnMyIxEzmi2X1shOBWsJHkrW2xkR58ABZF+4uWHEE73yDVR4SyYAikP9jstZzDRm+bcVs8+T0yaLiEGLrIIIL4esi1llhIkgErCuy5btPcWXBdio2fpCRD5x9oR6gmE/rd5O7lX1c1uvnv4r1Lkk4pqP2/iUfxFZva1xLSRvgyfm6D9hNklVyPfy+7TalMD0lzmJuOrExtnSIbZew3foxgx8GT+lbZkLd0ZdtdRJlIyPRP44eyq78sU0Eo/LsDr0Iak4ZDpg8dXg==\",
+   \"SigningCertURL\": \"https://sns.us-east-2.amazonaws.com/SimpleNotificationService-010a507c1833636cd94bdb98bd93083a.pem\",
+   \"UnsubscribeURL\": \"https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-2:111122223333:ExampleTopic1:e1039402-24e7-40a3-a0d4-797da162b297\"}"))))

--- a/test/sqs_consumer/utils_test.clj
+++ b/test/sqs_consumer/utils_test.clj
@@ -21,61 +21,64 @@
   ([]
    (test-sns-message {})))
 
-(deftest auto-decode-json-message-decodes-sns-with-no-args
+(defn- wrapped-message [message-body]
+  {:message-body message-body})
+
+(deftest auto-decode-json-message-decodes-sns-no-args
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001 :timestamp "2018-04-17T11:33:44.770Z"}
           :message-attributes {:Type "Orchestration.Services.Model.Pollution.PollutionMessage"
                                :AWS.SNS.MOBILE.MPNS.Type "token"}
           :sqs-consumer/metadata {:message-envelope :sns}}
-         ((utils/auto-decode-json-message) (test-sns-message)))))
+         ((utils/auto-json-decoder) (wrapped-message (test-sns-message))))))
 
 (deftest auto-decode-json-message-adds-timestamp-from-sns-message-if-absent
   (is (= "2020-04-17T11:33:44.770Z"
-         (-> ((utils/auto-decode-json-message)
-              (test-sns-message {"Timestamp" "2020-04-17T11:33:44.770Z"}))
+         (-> ((utils/auto-json-decoder)
+              (wrapped-message (test-sns-message {"Timestamp" "2020-04-17T11:33:44.770Z"})))
              :message-body
              :timestamp))))
 
 (deftest auto-decode-json-message-does-not-add-timestamp-from-sns-message-if-present
   (is (= "2017-01-12T09:33:44.770ZZ"
-         (-> ((utils/auto-decode-json-message)
-              (test-sns-message {"Message" "{\"timestamp\" \"2017-01-12T09:33:44.770ZZ\",\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}"
-                                 "Timestamp" "2020-04-17T11:33:44.770Z"}))
+         (-> ((utils/auto-json-decoder)
+              (wrapped-message (test-sns-message {"Message" "{\"timestamp\" \"2017-01-12T09:33:44.770ZZ\",\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}"
+                                                  "Timestamp" "2020-04-17T11:33:44.770Z"})))
              :message-body
              :timestamp))))
 
-(deftest auto-decode-json-message-decodes-sns-with-jsonista
+(deftest auto-decode-json-message-decodes-sns-jsonista
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001 :timestamp "2018-04-17T11:33:44.770Z"}
           :message-attributes {:Type "Orchestration.Services.Model.Pollution.PollutionMessage"
                                :AWS.SNS.MOBILE.MPNS.Type "token"}
           :sqs-consumer/metadata {:message-envelope :sns}}
-         ((utils/auto-decode-json-message #(jsonista/read-value % jsonista/keyword-keys-object-mapper)) (test-sns-message)))))
+         ((utils/auto-json-decoder #(jsonista/read-value % jsonista/keyword-keys-object-mapper)) (wrapped-message (test-sns-message))))))
 
-(deftest auto-decode-json-message-decodes-sqs-with-no-args
+(deftest auto-decode-json-message-decodes-sqs-no-args
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001}
           :sqs-consumer/metadata {:message-envelope :sqs}}
-         ((utils/auto-decode-json-message)
-          "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}"))))
+         ((utils/auto-json-decoder)
+          (wrapped-message "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}")))))
 
-(deftest auto-decode-json-message-decodes-sqs-with-jsonista
+(deftest auto-decode-json-message-decodes-sqs-jsonista
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001}
           :sqs-consumer/metadata {:message-envelope :sqs}}
-         ((utils/auto-decode-json-message #(jsonista/read-value % jsonista/keyword-keys-object-mapper))
-          "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}"))))
+         ((utils/auto-json-decoder #(jsonista/read-value % jsonista/keyword-keys-object-mapper))
+          (wrapped-message "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}")))))
 
 
-(deftest decode-sns-encoded-json-decodes-sns-with-no-args
+(deftest sns-encoded-json-decoder-decodes-sns-no-args
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001 :timestamp "2018-04-17T11:33:44.770Z"}
           :message-attributes {:Type "Orchestration.Services.Model.Pollution.PollutionMessage"
                                :AWS.SNS.MOBILE.MPNS.Type "token"}
           :sqs-consumer/metadata {:message-envelope :sns}}
-         ((utils/decode-sns-encoded-json) (test-sns-message)))))
+         ((utils/sns-encoded-json-decoder) (wrapped-message (test-sns-message))))))
 
 
-(deftest decode-sqs-encoded-json-decodes-sqs-with-no-args
+(deftest sqs-encoded-json-decoder-decodes-sqs-no-args
   (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001}
           :sqs-consumer/metadata {:message-envelope :sqs}}
-         ((utils/decode-sqs-encoded-json)
-          "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}"))))
+         ((utils/sqs-encoded-json-decoder)
+          (wrapped-message "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}")))))
 
 (deftest uuid-returns-a-v4-uuid-as-a-string
   (let [uuid (utils/uuid)]

--- a/test/sqs_consumer/utils_test.clj
+++ b/test/sqs_consumer/utils_test.clj
@@ -1,16 +1,84 @@
 (ns sqs-consumer.utils-test
   (:require [clojure.test :refer [deftest is]]
-            [sqs-consumer.utils :as utils]))
+            [sqs-consumer.utils :as utils]
+            [jsonista.core :as jsonista]))
 
-(deftest auto-decode-json-message-decodes-sns
-  (is (= "" ((utils/auto-decode-json-message) "{
-   \"Type\": \"Notification\",
-   \"MessageId\": \"dc1e94d9-56c5-5e96-808d-cc7f68faa162\",
-   \"TopicArn\": \"arn:aws:sns:us-east-2:665242997532:ExampleTopic1\",
-   \"Subject\": \"TestSubject\",
-   \"Message\": \"\",
-   \"Timestamp\": \"2021-02-16T21:41:19.978Z\",
-   \"SignatureVersion\": \"1\",
-   \"Signature\": \"FMG5tlZhJNHLHUXvZgtZzlk24FzVa7oX0T4P03neeXw8ZEXZx6z35j2FOTuNYShn2h0bKNC/zLTnMyIxEzmi2X1shOBWsJHkrW2xkR58ABZF+4uWHEE73yDVR4SyYAikP9jstZzDRm+bcVs8+T0yaLiEGLrIIIL4esi1llhIkgErCuy5btPcWXBdio2fpCRD5x9oR6gmE/rd5O7lX1c1uvnv4r1Lkk4pqP2/iUfxFZva1xLSRvgyfm6D9hNklVyPfy+7TalMD0lzmJuOrExtnSIbZew3foxgx8GT+lbZkLd0ZdtdRJlIyPRP44eyq78sU0Eo/LsDr0Iak4ZDpg8dXg==\",
-   \"SigningCertURL\": \"https://sns.us-east-2.amazonaws.com/SimpleNotificationService-010a507c1833636cd94bdb98bd93083a.pem\",
-   \"UnsubscribeURL\": \"https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-2:111122223333:ExampleTopic1:e1039402-24e7-40a3-a0d4-797da162b297\"}"))))
+(defn- test-sns-message
+  ([opts] (jsonista/write-value-as-string
+           (merge
+            {"Type" "Notification"
+             "MessageId" "78d5bc6f-142c-5060-a75c-ef29b774ec66"
+             "TopicArn" "arn:aws:sns:eu-west-2:xxx:pollution-event"
+             "Message" "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}"
+             "Timestamp" "2018-04-17T11:33:44.770Z"
+             "SignatureVersion" "1"
+             "Signature" "xxx=="
+             "SigningCertURL" "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-xxx.pem"
+             "MessageAttributes" {"Type" {"Type" "String"
+                                          "Value" "Orchestration.Services.Model.Pollution.PollutionMessage"}
+                                  "AWS.SNS.MOBILE.MPNS.Type" {"Type" "String"
+                                                              "Value" "token"}}} opts)))
+  ([]
+   (test-sns-message {})))
+
+(deftest auto-decode-json-message-decodes-sns-with-no-args
+  (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001 :timestamp "2018-04-17T11:33:44.770Z"}
+          :message-attributes {:Type "Orchestration.Services.Model.Pollution.PollutionMessage"
+                               :AWS.SNS.MOBILE.MPNS.Type "token"}
+          :sqs-consumer/metadata {:message-envelope :sns}}
+         ((utils/auto-decode-json-message) (test-sns-message)))))
+
+(deftest auto-decode-json-message-adds-timestamp-from-sns-message-if-absent
+  (is (= "2020-04-17T11:33:44.770Z"
+         (-> ((utils/auto-decode-json-message)
+              (test-sns-message {"Timestamp" "2020-04-17T11:33:44.770Z"}))
+             :message-body
+             :timestamp))))
+
+(deftest auto-decode-json-message-does-not-add-timestamp-from-sns-message-if-present
+  (is (= "2017-01-12T09:33:44.770ZZ"
+         (-> ((utils/auto-decode-json-message)
+              (test-sns-message {"Message" "{\"timestamp\" \"2017-01-12T09:33:44.770ZZ\",\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}"
+                                 "Timestamp" "2020-04-17T11:33:44.770Z"}))
+             :message-body
+             :timestamp))))
+
+(deftest auto-decode-json-message-decodes-sns-with-jsonista
+  (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001 :timestamp "2018-04-17T11:33:44.770Z"}
+          :message-attributes {:Type "Orchestration.Services.Model.Pollution.PollutionMessage"
+                               :AWS.SNS.MOBILE.MPNS.Type "token"}
+          :sqs-consumer/metadata {:message-envelope :sns}}
+         ((utils/auto-decode-json-message #(jsonista/read-value % jsonista/keyword-keys-object-mapper)) (test-sns-message)))))
+
+(deftest auto-decode-json-message-decodes-sqs-with-no-args
+  (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001}
+          :sqs-consumer/metadata {:message-envelope :sqs}}
+         ((utils/auto-decode-json-message)
+          "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}"))))
+
+(deftest auto-decode-json-message-decodes-sqs-with-jsonista
+  (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001}
+          :sqs-consumer/metadata {:message-envelope :sqs}}
+         ((utils/auto-decode-json-message #(jsonista/read-value % jsonista/keyword-keys-object-mapper))
+          "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}"))))
+
+
+(deftest decode-sns-encoded-json-decodes-sns-with-no-args
+  (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001 :timestamp "2018-04-17T11:33:44.770Z"}
+          :message-attributes {:Type "Orchestration.Services.Model.Pollution.PollutionMessage"
+                               :AWS.SNS.MOBILE.MPNS.Type "token"}
+          :sqs-consumer/metadata {:message-envelope :sns}}
+         ((utils/decode-sns-encoded-json) (test-sns-message)))))
+
+
+(deftest decode-sqs-encoded-json-decodes-sqs-with-no-args
+  (is (= {:message-body {:validFrom "2018-03-10T09:00:00Z" :validTo "2018-03-11T09:00:00Z" :eventLevelId 1 :eventTypeId 1 :operatorId 3375001}
+          :sqs-consumer/metadata {:message-envelope :sqs}}
+         ((utils/decode-sqs-encoded-json)
+          "{\"validFrom\": \"2018-03-10T09:00:00Z\",\"validTo\": \"2018-03-11T09:00:00Z\",\"eventLevelId\": 1,\"eventTypeId\": 1,\"operatorId\": 3375001}"))))
+
+(deftest uuid-returns-a-v4-uuid-as-a-string
+  (let [uuid (utils/uuid)]
+    (is (string? uuid))
+    (is (= 36 (count uuid)))
+    (is (true? (clojure.core/uuid? (java.util.UUID/fromString uuid))))))


### PR DESCRIPTION
Few things here, was going to do more small commits but got into a rabbit hole as I needed to alter non body attributes in decoders when parsing attributes from SNS messages.

* Don't require clojure.data.json
* Don't load utils from any other namespace
* Do load core from utils (assumed you'd already have core if using utils, not vice-versa)
* Parse message attributes if they're on SNS messages, or on the actual SQS message attributes - if they're from SNS they end up on the actual JSON message envelope rather than on the `:message-attributes` property of the received message.
* Add 'auto json parser' function if you want to support both and/or don't care
* Convert decoder functions to be higher order functions to allow dropping clojure.data.json dep, lazy load using a macro instead (com.clojure-goes-fast/lazy-require)
* Pass the following map to each process-fn, rather than losing anything but the body (needed for tracing as an example if you want to capture the trace on message attributes). Add bound `change-message-visibility`
* 
	```clojure
   :message message
   ;; attributes on the message, note these are different to message-attributes, e.g. ApproximateReceiveCount
   :attributes (:attributes message)
   ;; the message body itself. If this was the message from SNS it is wrapped in an SNS envelope unless RawMessageDelivery is set to true
   :message-body (:body message)
   ;; map of any message attributes set via the SQS send-message API
   :message-attributes (core/parse-message-attributes (:message-attributes message))
   ;; the sqs delete message API call pre-bound to the given message/aws config
   :delete-message #(delete-message config (:receipt-handle message))
    ;; the sqs change message visibility API call pre-bound to the given message/AWS config
   :change-message-visibility #(change-message-visibility config (:receipt-handle message) %)})
   ```

* Update docs to reflect actual usage currently
* Return a function on `:running` when calling `create-consumer` which returns if the consumer is running
* Add clojure.tools.logging as logging implementation (will probably end up going to slf4j in most cases, its backend agnostic)
* Adds tests for message parsing, including using clojure.data.json and jsonista
* Warn on reflection everywhere - there isn't any reflection atm 🎉 
* Fix up some doc comments in the wrong places, tidy unused args, make the parallel test less flakey by using sets to remove reliance on order
* Rename some functions to match the README and be consistent.

Batch is still only passing through bodies, I think that would need more love.

This is obviously breaking in a fair few places but I think it makes sense. The alternative IMO would probably be to do some reflection on process-fn, find out how many args it expects, and if it expects 2, calling it with [body {:message, :message-attributes, ...etc}]. Even then this is still breaking due to some removed functions and change in decoder signature.