### PR TITLE
Add opentracing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1
+
+    - Add opentracing support, see `sqs-consumer.opentracing`
+
 ## 0.3.0
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -154,6 +154,34 @@ To use [cheshire](https://github.com/dakrone/cheshire):
 
 If you pass `queue-url` then `queue-name` will never be used. If you only pass `queue-name` then `queue-url` will be looked up; AWS will throw an exception if a Queue with that name cannot be found. If neither are passed then an `IllegalArgumentException` will be thrown.
 
+### Tracing
+
+To add tracing add `sqs-consumer.opentracing/with-tracing` to your `process-fn`. This requires the [opentracing-clj](https://github.com/alvinfrancis/opentracing-clj) library on your classpath (this is not included).
+
+This function attempts to extract existing span context from upstream services. This context will be pulled from `:message-attributes` using the given key, assuming the `text` opentracing carrier format.
+
+If using an SNS message without `RawMessageDelivery` set to `true`, it must be placed _after_ the decoder, else the span context from the upstream service will not have yet been pulled from the message attributes.
+
+```clojure
+(require [sqs-consumer.parallel :as queue.parallel]
+         [sqs-consumer.opentracing :as queue.opentracing]
+         [sqs-consumer.utils :as queue.utils])
+
+:process-fn (-> process
+  (queue.opentracing/with-tracing :span-ctx) ;; replace span-ctx with the name of the attribute you propagate traces through on an SNS or SQS message attribute
+  (queue.parallel/with-decoder (queue.utils/auto-decode-json-message))
+  (queue.parallel/with-error-handling #(prn % "error processing messages")))
+```
+
+If using SNS with `RawMessageDelivery` set to `true` or raw SQS messages, `with-tracing` can be placed earlier in the process-fn order, i.e. before the decoder. This means errors in decoders will still be traced.
+
+```clojure
+:process-fn (-> process
+  (queue.parallel/with-decoder (queue.utils/decode-sqs-encoded-json))
+  (queue.opentracing/with-tracing :span-ctx)
+  (queue.parallel/with-error-handling #(prn % "error processing messages")))
+```
+
 ## TODO
 
 -   [ ] deps.edn?

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If you pass `queue-url` then `queue-name` will never be used. If you only pass `
 
 ### Tracing
 
-To add tracing add `sqs-consumer.opentracing/with-tracing` to your `process-fn`. This requires the [opentracing-clj](https://github.com/alvinfrancis/opentracing-clj) library on your classpath (this is not included).
+To add tracing add `sqs-consumer.opentracing/with-tracing` to your `process-fn`. This requires the [opentracing-clj](https://github.com/alvinfrancis/opentracing-clj) library (with version > "0.2.2") on your classpath (this is not included).
 
 This function attempts to extract existing span context from upstream services. This context will be pulled from `:message-attributes` using the given key, assuming the `text` opentracing carrier format.
 

--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,8 @@
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.2"]
 
                                   [org.clojure/data.json "1.0.0"]
+                                  [opentracing-clj "0.2.2"]
+                                  [io.opentracing/opentracing-mock "0.33.0"]
                                   [metosin/jsonista "0.3.1"]
                                   [com.climate/claypoole "1.1.4"]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.signal-ai/sqs-consumer "0.3.0"
+(defproject com.signal-ai/sqs-consumer "0.3.1"
   :description "Another SQS Library"
   :url "https://github.com/signal-ai/sqs-consumer"
   :license {:name "Eclipse Public License"

--- a/src/sqs_consumer/opentracing.clj
+++ b/src/sqs_consumer/opentracing.clj
@@ -1,0 +1,35 @@
+(ns sqs-consumer.opentracing
+  (:require
+   [sqs-consumer.core :as core]
+   [opentracing-clj.core :as tracing]
+   [opentracing-clj.propagation :as propagation])
+  (:import [io.opentracing.tag Tag Tags]))
+
+(defn- tag
+  "Returns the key for the opentracing Java Tag object."
+  [^Tag tag]
+  (.getKey tag))
+
+(defn with-tracing
+  "Add a trace to the queue. Propagates context from the :span-ctx attribute if it exists.
+   
+   If the queue messages are from SNS with RawMessageDelivery set to true should be placed after message decoding (e.g. sqs-consumer.utils/decode-sns-encoded-json)
+   so any span context can be propagated from message attributes.
+   Otherwise can be placed earlier."
+  [process-fn span-context-attribute-name]
+  (fn [message]
+    (let [ctx (when-let [carrier (-> message :message-attributes span-context-attribute-name)] (propagation/extract carrier :text))]
+      (tracing/with-span [s
+                          {:name (format "queue-%s-message-recieved" (-> message ::core/config :queue-name))
+                           :tags (cond-> {(tag Tags/COMPONENT) "signal-ai/sqs-consumer"
+                                          (tag Tags/SPAN_KIND) Tags/SPAN_KIND_CONSUMER
+                                          (tag Tags/PEER_SERVICE) "sqs"
+                                          (tag Tags/PEER_ADDRESS) (-> message ::core/config :queue-url)}
+                                   ctx (assoc :child-of ctx))}]
+        (try
+          (process-fn message)
+          (catch Throwable e
+            (tracing/set-tags {(tag Tags/ERROR) true})
+            (tracing/log {:event "error"
+                          :error.object e})
+            (throw e)))))))

--- a/src/sqs_consumer/opentracing.clj
+++ b/src/sqs_consumer/opentracing.clj
@@ -15,12 +15,12 @@
   (fn [message]
     (let [ctx (when-let [carrier (-> message :message-attributes span-context-attribute-name)] (propagation/extract carrier :text))]
       (tracing/with-span [s
-                          {:name (format "queue-%s-message-recieved" (-> message ::core/config :queue-name))
-                           :tags (cond-> {Tags/COMPONENT "signal-ai/sqs-consumer"
-                                          Tags/SPAN_KIND Tags/SPAN_KIND_CONSUMER
-                                          Tags/PEER_SERVICE "sqs"
-                                          Tags/PEER_ADDRESS (-> message ::core/config :queue-url)}
-                                   ctx (assoc :child-of ctx))}]
+                          (cond-> {:name (format "queue-%s-message-recieved" (-> message ::core/config :queue-name))
+                                   :tags {(.getKey Tags/COMPONENT) "signal-ai/sqs-consumer"
+                                          (.getKey Tags/SPAN_KIND) Tags/SPAN_KIND_CONSUMER
+                                          (.getKey Tags/PEER_SERVICE) "sqs"
+                                          "peer.address" (-> message ::core/config :queue-url)}}
+                            ctx (assoc :child-of ctx))]
         (try
           (process-fn message)
           (catch Throwable e

--- a/test/sqs_consumer/localstack.clj
+++ b/test/sqs_consumer/localstack.clj
@@ -10,15 +10,16 @@
                  :endpoint (format "http://%s:4566" localstack-host)
                  :client-config {}})
 
+(def ^:private localstack-retry-count (atom 0))
+
 (defn wait-for-localstack []
-  (let [localstack-url (format "http://%s:4566/health" localstack-host)
-        localstack-retry-count (atom 0)]
-    (log/infof "looking up localstack at %s" localstack-url)
+  (let [localstack-url (format "http://%s:4566/health" localstack-host)]
+    (log/infof "looking up localstack at %s, retry no: %s" localstack-url  @localstack-retry-count)
     (try
       (slurp localstack-url)
       (log/infof "localstack ready at %s" localstack-url)
       (catch Exception e
-        (if (>= @localstack-retry-count 20)
+        (if (>= @localstack-retry-count 10)
           (do
             (log/fatalf "retry limit reached waiting for localstack at %s, %s" localstack-url)
             (System/exit 1))

--- a/test/sqs_consumer/opentracing_test.clj
+++ b/test/sqs_consumer/opentracing_test.clj
@@ -1,0 +1,122 @@
+(ns sqs-consumer.opentracing-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [sqs-consumer.sequential :as seq]
+            [sqs-consumer.opentracing :as opentracing]
+            [opentracing-clj.core :as tracing]
+            [opentracing-clj.propagation :as propagation])
+  (:import
+   [io.opentracing References]
+   [io.opentracing.mock MockTracer MockSpan]))
+
+
+(defn with-mock-tracer
+  [f]
+  (binding [tracing/*tracer* (new MockTracer)]
+    (f)))
+
+(def ^:private processing-fn-calls (atom {:args []}))
+(def ^:private span-state (atom {:span nil
+                                 :tags nil}))
+
+(use-fixtures :each (fn [f]
+                      (reset! processing-fn-calls {:args []})
+                      (reset! span-state {:span nil
+                                          :tags nil})
+                      (with-mock-tracer f)))
+
+(deftest traces-messages
+  (let [message-body {:id "123"
+                      :attribute {:sub-attribute true}}
+        processing-function (fn  [& args]
+                              (swap! processing-fn-calls #(hash-map :args (conj (:args %) args)))
+                              (swap! span-state (constantly (tracing/active-span))))
+        process-fn (-> processing-function
+                       (opentracing/with-tracing :span-ctx))
+        message {:body message-body}
+        config {:visibility-timeout 123
+                :queue-url "https://sqs.us-east-1.amazonaws.com/1234567890/default_development"
+                :queue-name "some-queue-name"}
+        initial-message (seq/extract-message config message)]
+
+    (process-fn initial-message)
+    (testing "passes through message unchanged"
+      (is (= 1 (-> @processing-fn-calls :args count)) "Expected process-fn to be called once")
+      (is (= 1 (-> @processing-fn-calls :args first count)) "Expected process-fn to be called with one argument")
+      (is (= initial-message (-> @processing-fn-calls :args first first))))
+
+    (testing "sets span, tags and operation name correctly"
+      (is (instance? MockSpan  @span-state))
+      (is (= {"component" "signal-ai/sqs-consumer"
+              "peer.service" "sqs"
+              "span.kind" "consumer"
+              "peer.address" (:queue-url config)} (.tags @span-state)))
+      (is (= "queue-some-queue-name-message-recieved" (.operationName @span-state)))
+      (is (= 1 (count (.finishedSpans tracing/*tracer*)))))))
+
+(deftest sets-trace-error-on-process-error
+  (let [message-body {:id "123"
+                      :attribute {:sub-attribute true}}
+        given-error (ex-info "Processing-error" {})
+        processing-function (fn  [& args]
+                              (swap! processing-fn-calls #(hash-map :args (conj (:args %) args)))
+                              (swap! span-state (constantly (tracing/active-span)))
+                              (throw given-error))
+        process-fn (-> processing-function
+                       (opentracing/with-tracing :span-ctx))
+        message {:body message-body}
+        config {:visibility-timeout 123
+                :queue-url "https://sqs.eu-west-1.amazonaws.com/1234567800/other_development"
+                :queue-name "other-queue-name"}
+        initial-message (seq/extract-message config message)]
+
+    (try
+      (process-fn initial-message)
+      (catch Throwable e
+        (is (= given-error e))))
+    (testing "sets span, tags and operation name correctly, with error"
+      (is (instance? MockSpan  @span-state))
+      (is (= {"component" "signal-ai/sqs-consumer"
+              "peer.service" "sqs"
+              "span.kind" "consumer"
+              "peer.address" (:queue-url config)
+              "error" true} (.tags @span-state)))
+      (is (= "queue-other-queue-name-message-recieved" (.operationName @span-state)))
+      (is (= 1 (count (.finishedSpans tracing/*tracer*)))))))
+
+(deftest propagates-headers-from-attributes
+  (let [original-span (atom nil)
+        propagation-headers (tracing/with-span [s {:name "original-span"}]
+                              (reset! original-span s)
+                              (propagation/inject :text))
+        trace-attribute :span-ctx
+
+        message-body {:id "123"
+                      :attribute {:sub-attribute true}}
+        given-error (ex-info "Processing-error" {})
+        processing-function (fn  [& args]
+                              (swap! processing-fn-calls #(hash-map :args (conj (:args %) args)))
+                              (swap! span-state (constantly (tracing/active-span))))
+        process-fn (-> processing-function
+                       (opentracing/with-tracing trace-attribute))
+        message {:body message-body}
+        config {:queue-url "https://sqs.eu-west-1.amazonaws.com/1234567800/other_development"
+                :queue-name "other-queue-name"}
+        initial-message (assoc (seq/extract-message config message) :message-attributes {trace-attribute propagation-headers})]
+
+    (try
+      (process-fn initial-message)
+      (catch Throwable e
+        (is (= given-error e))))
+    (testing "sets child context correctly"
+      (is (instance? MockSpan  @span-state))
+      (is (= {"component" "signal-ai/sqs-consumer"
+              "peer.service" "sqs"
+              "span.kind" "consumer"
+              "peer.address" (:queue-url config)} (.tags @span-state)))
+
+      (let [original-span-trace-id (.toTraceId (.context @original-span))
+            child-span-references  (.references @span-state)]
+        (is (= 1 (count child-span-references)))
+        (is (not (nil? original-span-trace-id)))
+        (is (= [References/CHILD_OF original-span-trace-id]
+               [(.getReferenceType (first child-span-references)) (.toTraceId (.getContext (first child-span-references)))]))))))


### PR DESCRIPTION
Follow on from #1, adds opentracing namespace with a handler to add opentracing to message reads.

There's some annoying ordering of middleware here, assuming traces are propagated via message attributes. This is due to varying placement of attributes depending on the origin of the message, see https://stackoverflow.com/questions/44238656/how-to-add-sqs-message-attributes-in-sns-subscription. 

It might be better to split this into two handlers, one of which creates the first span, and another after decoding which sets tags and logs.

~Could also do with some tests to check the span context after the function has been applied.~

There's also an argument this should aim to support opentelemetry instead as it's now out for Java and there's a shim for opentelemetry -> opentracing...